### PR TITLE
Fix: Surround boolean values with single quotes

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -39,9 +39,9 @@ services:
       RUST_BACKTRACE: 1;
       MONGODB_URI: mongodb://kronk:5RwjSCNN@mongo:27017/
       DB_NAME: rust_at_one
-      USE_SSL: true
+      USE_SSL: "true"
       KEY_PEM: /certs/nopass.pem
       CERT_PEM: /certs/cert.pem
-      USE_LE: false
+      USE_LE: "false"
       LE_EMAIL: NotUsed
       LE_DOMAIN: NotUsed


### PR DESCRIPTION
From the Docker documentation:

>   YAML boolean values ("true", "false", "yes", "no", "on", "off") must be
>   enclosed in quotes, so that the parser interprets them as strings.